### PR TITLE
Adding support for moving karpenter to kube-system

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Truefoundry AWS Karpenter Module
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Cluster Name to install karpenter | `string` | n/a | yes |
 | <a name="input_controller_node_iam_role_arn"></a> [controller\_node\_iam\_role\_arn](#input\_controller\_node\_iam\_role\_arn) | The node iam role for the initial node group to be used by karpenter | `string` | n/a | yes |
 | <a name="input_controller_nodegroup_name"></a> [controller\_nodegroup\_name](#input\_controller\_nodegroup\_name) | The initial nodegroup name | `string` | n/a | yes |
-| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s karpenter service account name | `string` | n/a | yes |
-| <a name="input_k8s_service_account_namespace"></a> [k8s\_service\_account\_namespace](#input\_k8s\_service\_account\_namespace) | The k8s karpenter namespace | `string` | n/a | yes |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s karpenter service account name | `string` | `"karpenter"` | no |
+| <a name="input_k8s_service_account_namespace"></a> [k8s\_service\_account\_namespace](#input\_k8s\_service\_account\_namespace) | The k8s karpenter namespace | `string` | `"kube-system"` | no |
 | <a name="input_message_retention_seconds"></a> [message\_retention\_seconds](#input\_message\_retention\_seconds) | Message retention in seconds for SQS queue | `number` | `300` | no |
 | <a name="input_oidc_provider_arn"></a> [oidc\_provider\_arn](#input\_oidc\_provider\_arn) | The oidc provider  arn of the eks cluster | `string` | n/a | yes |
 | <a name="input_sqs_enable_encryption"></a> [sqs\_enable\_encryption](#input\_sqs\_enable\_encryption) | Enable Server side encryption for SQS | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Truefoundry AWS Karpenter Module
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_karpenter_irsa_role"></a> [karpenter\_irsa\_role](#module\_karpenter\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.42.0 |
+| <a name="module_karpenter_irsa_role"></a> [karpenter\_irsa\_role](#module\_karpenter\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.48.0 |
 
 ## Resources
 

--- a/locals.tf
+++ b/locals.tf
@@ -47,5 +47,5 @@ locals {
     },
     var.additional_controller_role_policies_arn
   )
-  service_account_namespaces = var.k8s_service_account_namespace == "karpenter" ? ["${var.k8s_service_account_namespace}:${var.k8s_service_account_name}"] : ["${var.k8s_service_account_namespace}:${var.k8s_service_account_name}","karpenter:${var.k8s_service_account_name}"]
+  service_account_namespaces = var.k8s_service_account_namespace == "karpenter" ? ["${var.k8s_service_account_namespace}:${var.k8s_service_account_name}"] : ["${var.k8s_service_account_namespace}:${var.k8s_service_account_name}", "karpenter:${var.k8s_service_account_name}"]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -47,4 +47,5 @@ locals {
     },
     var.additional_controller_role_policies_arn
   )
+  service_account_namespaces = var.k8s_service_account_namespace == "karpenter" ? ["${var.k8s_service_account_namespace}:${var.k8s_service_account_name}"] : ["${var.k8s_service_account_namespace}:${var.k8s_service_account_name}","karpenter:${var.k8s_service_account_name}"]
 }

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ module "karpenter_irsa_role" {
   oidc_providers = {
     main = {
       provider_arn               = var.oidc_provider_arn
-      namespace_service_accounts = ["${var.k8s_service_account_namespace}:${var.k8s_service_account_name}"]
+      namespace_service_accounts = local.service_account_namespaces
     }
   }
   tags = local.tags

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 
 module "karpenter_irsa_role" {
   source                             = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version                            = "5.42.0"
+  version                            = "5.48.0"
   role_name                          = "${var.cluster_name}-karpenter"
   attach_karpenter_controller_policy = true
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,11 +6,13 @@ variable "cluster_name" {
 variable "k8s_service_account_name" {
   description = "The k8s karpenter service account name"
   type        = string
+  default     = "karpenter"
 }
 
 variable "k8s_service_account_namespace" {
   description = "The k8s karpenter namespace"
   type        = string
+  default     = "kube-system"
 }
 
 variable "oidc_provider_arn" {


### PR DESCRIPTION
Adding support for karpenter in `kube-system` namespace as well. This will be removed in the next minor release `v0.4+`