### PR TITLE
Fix resource address in moved block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,6 @@ moved {
 }
 
 moved {
-  from = resource.aws_iam_instance_profile.karpenter
-  to   = resource.aws_iam_instance_profile.karpenter[0]
+  from = aws_iam_instance_profile.karpenter
+  to   = aws_iam_instance_profile.karpenter[0]
 }


### PR DESCRIPTION
- Updated the 'from' and 'to' addresses in the moved block to remove the 'resource.' prefix, aligning with Terraform's expected resource addressing format.
- Terraform silently allows this, OpenTofu throws an error.